### PR TITLE
SUMO-91110: Resource names generalized for Eventhub logs template

### DIFF
--- a/EventHubs/src/azuredeploy_activity_logs.json
+++ b/EventHubs/src/azuredeploy_activity_logs.json
@@ -2,28 +2,28 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "sites_SumoAzureAuditApp_name": {
-            "defaultValue": "[concat('SumoAzureAuditApp', uniqueString(resourceGroup().id))]",
+        "sites_SumoAzureLogsFunctionApp_name": {
+            "defaultValue": "[concat('SumoAzureLogsFunctionApp', uniqueString(resourceGroup().id))]",
             "type": "String"
         },
-        "storageAccounts_SumoAzureAudit_name": {
-            "defaultValue": "[concat('sumoaudfail',uniqueString(resourceGroup().id))]",
+        "storageAccounts_SumoAzureFailedMsg_name": {
+            "defaultValue": "[concat('sumofailmsg',uniqueString(resourceGroup().id))]",
             "type": "String"
         },
-        "namespaces_SumoAzureAudit_name": {
-            "defaultValue": "[concat('SumoAzureAudit', uniqueString(resourceGroup().id))]",
+        "namespaces_SumoAzureLogs_name": {
+            "defaultValue": "[concat('SumoAzureLogsNamespace', uniqueString(resourceGroup().id))]",
             "type": "String"
         },
-        "serverfarms_SumoAzureAuditAppServicePlan_name": {
-            "defaultValue": "[concat('SumoAzureAuditAppServicePlan', uniqueString(resourceGroup().id))]",
+        "serverfarms_SumoAzureLogsAppServicePlan_name": {
+            "defaultValue": "[concat('SumoAzureLogsAppServicePlan', uniqueString(resourceGroup().id))]",
             "type": "String"
         },
         "config_web_name": {
             "defaultValue": "web",
             "type": "String"
         },
-        "storageAccounts_SumoAzureAuditAppLogs_name": {
-            "defaultValue": "[concat('sumoaudlogs', uniqueString(resourceGroup().id))]",
+        "storageAccounts_SumoAzureAppLogs_name": {
+            "defaultValue": "[concat('sumoapplogs', uniqueString(resourceGroup().id))]",
             "type": "String"
         },
         "eventhubs_insights_operational_logs_name": {
@@ -32,10 +32,6 @@
         },
         "AuthorizationRules_RootManageSharedAccessKey_name": {
             "defaultValue": "RootManageSharedAccessKey",
-            "type": "String"
-        },
-        "hostNameBindings_sumoazureauditapp.azurewebsites.net_name": {
-            "defaultValue": "[concat('sumoazureauditapp', uniqueString(resourceGroup().id),'.azurewebsites.net')]",
             "type": "String"
         },
         "consumergroups_$Default_name": {
@@ -68,7 +64,7 @@
                 "tier": "Standard",
                 "capacity": 1
             },
-            "name": "[parameters('namespaces_SumoAzureAudit_name')]",
+            "name": "[parameters('namespaces_SumoAzureLogs_name')]",
             "apiVersion": "2017-04-01",
             "location": "[resourceGroup().location]",
             "tags": {},
@@ -77,10 +73,10 @@
                 "isAutoInflateEnabled": true,
                 "maximumThroughputUnits": 20,
                 "provisioningState": "Succeeded",
-                "metricId": "[concat('c088dc46-d692-42ad-a4b6-9a542d28ad2a:sumoazureaudit', parameters('namespaces_SumoAzureAudit_name'))]",
+                "metricId": "[concat('c088dc46-d692-42ad-a4b6-9a542d28ad2a:sumoazurelogs', parameters('namespaces_SumoAzureLogs_name'))]",
                 "createdAt": "2018-01-17T09:33:37.26Z",
                 "updatedAt": "2018-01-17T09:34:00.52Z",
-                "serviceBusEndpoint": "[concat('https://', parameters('namespaces_SumoAzureAudit_name'),'.servicebus.windows.net:443/')]"
+                "serviceBusEndpoint": "[concat('https://', parameters('namespaces_SumoAzureLogs_name'),'.servicebus.windows.net:443/')]"
             },
             "dependsOn": []
         },
@@ -91,7 +87,7 @@
                 "tier": "Standard"
             },
             "kind": "Storage",
-            "name": "[parameters('storageAccounts_SumoAzureAudit_name')]",
+            "name": "[parameters('storageAccounts_SumoAzureFailedMsg_name')]",
             "apiVersion": "2017-06-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -118,7 +114,7 @@
                 "tier": "Standard"
             },
             "kind": "Storage",
-            "name": "[parameters('storageAccounts_SumoAzureAuditAppLogs_name')]",
+            "name": "[parameters('storageAccounts_SumoAzureAppLogs_name')]",
             "apiVersion": "2017-06-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -147,12 +143,12 @@
                 "capacity": 1
             },
             "kind": "app",
-            "name": "[parameters('serverfarms_SumoAzureAuditAppServicePlan_name')]",
+            "name": "[parameters('serverfarms_SumoAzureLogsAppServicePlan_name')]",
             "apiVersion": "2016-09-01",
             "location": "[resourceGroup().location]",
             "scale": null,
             "properties": {
-                "name": "[parameters('serverfarms_SumoAzureAuditAppServicePlan_name')]",
+                "name": "[parameters('serverfarms_SumoAzureLogsAppServicePlan_name')]",
                 "workerTierName": null,
                 "adminSiteName": null,
                 "hostingEnvironmentProfile": null,
@@ -166,12 +162,14 @@
         {
             "type": "Microsoft.Web/sites",
             "kind": "functionapp",
-            "name": "[parameters('sites_SumoAzureAuditApp_name')]",
+            "name": "[parameters('sites_SumoAzureLogsFunctionApp_name')]",
             "apiVersion": "2016-08-01",
             "location": "[resourceGroup().location]",
             "scale": null,
             "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverfarms_SumoAzureAuditAppServicePlan_name'))]",
+                "enabled": true,
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverfarms_SumoAzureLogsAppServicePlan_name'))]",
+                "reserved": false,
                 "siteConfig": {
                     "alwaysOn": true,
                     "appSettings": [
@@ -186,24 +184,24 @@
                 "name": "appsettings",
                 "type": "config",
                 "dependsOn": [
-                  "[resourceId('Microsoft.Web/Sites', parameters('sites_SumoAzureAuditApp_name'))]",
-                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoAzureAuditApp_name'), 'web')]",
-                  "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAuditAppLogs_name'))]"
+                  "[resourceId('Microsoft.Web/Sites', parameters('sites_SumoAzureLogsFunctionApp_name'))]",
+                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoAzureLogsFunctionApp_name'), 'sourcecontrolsettings')]",
+                  "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAppLogs_name'))]"
                 ],
                 "properties": {
-                  "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_SumoAzureAuditAppLogs_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAuditAppLogs_name')),'2015-05-01-preview').key1)]",
-                  "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_SumoAzureAuditAppLogs_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAuditAppLogs_name')),'2015-05-01-preview').key1)]",
+                  "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_SumoAzureAppLogs_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAppLogs_name')),'2015-05-01-preview').key1)]",
+                  "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_SumoAzureAppLogs_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAppLogs_name')),'2015-05-01-preview').key1)]",
                   "SumoAuditEndpoint": "[parameters('SumoEndpointURL')]",
-                  "AzureEventHubConnectionString": "[listkeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('namespaces_SumoAzureAudit_name'),parameters('AuthorizationRules_RootManageSharedAccessKey_name')), '2017-04-01').primaryConnectionString]",
-                  "StorageConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_SumoAzureAudit_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAudit_name')),'2015-05-01-preview').key1,';EndpointSuffix=core.windows.net')]"
+                  "AzureEventHubConnectionString": "[listkeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('namespaces_SumoAzureLogs_name'),parameters('AuthorizationRules_RootManageSharedAccessKey_name')), '2017-04-01').primaryConnectionString]",
+                  "StorageConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_SumoAzureFailedMsg_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureFailedMsg_name')),'2015-05-01-preview').key1,';EndpointSuffix=core.windows.net')]"
                 }
              },
              {
                   "apiVersion": "2015-08-01",
-                  "name": "web",
+                  "name": "sourcecontrolsettings",
                   "type": "sourcecontrols",
                   "dependsOn": [
-                    "[resourceId('Microsoft.Web/sites/', parameters('sites_SumoAzureAuditApp_name'))]"
+                    "[resourceId('Microsoft.Web/sites/', parameters('sites_SumoAzureLogsFunctionApp_name'))]"
                   ],
                   "properties": {
                     "RepoUrl": "[parameters('sourceCodeRepositoryURL')]",
@@ -213,14 +211,14 @@
              }
             ],
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', parameters('serverfarms_SumoAzureAuditAppServicePlan_name'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAuditAppLogs_name'))]",
-                "[concat('Microsoft.EventHub/namespaces/', parameters('namespaces_SumoAzureAudit_name'))]"
+                "[resourceId('Microsoft.Web/serverfarms', parameters('serverfarms_SumoAzureLogsAppServicePlan_name'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAppLogs_name'))]",
+                "[concat('Microsoft.EventHub/namespaces/', parameters('namespaces_SumoAzureLogs_name'))]"
             ]
         },
         {
             "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
-            "name": "[concat(parameters('namespaces_SumoAzureAudit_name'), '/', parameters('AuthorizationRules_RootManageSharedAccessKey_name'))]",
+            "name": "[concat(parameters('namespaces_SumoAzureLogs_name'), '/', parameters('AuthorizationRules_RootManageSharedAccessKey_name'))]",
             "apiVersion": "2017-04-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -232,12 +230,12 @@
                 ]
             },
             "dependsOn": [
-                "[resourceId('Microsoft.EventHub/namespaces', parameters('namespaces_SumoAzureAudit_name'))]"
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('namespaces_SumoAzureLogs_name'))]"
             ]
         },
         {
             "type": "Microsoft.EventHub/namespaces/eventhubs",
-            "name": "[concat(parameters('namespaces_SumoAzureAudit_name'), '/', parameters('eventhubs_insights_operational_logs_name'))]",
+            "name": "[concat(parameters('namespaces_SumoAzureLogs_name'), '/', parameters('eventhubs_insights_operational_logs_name'))]",
             "apiVersion": "2017-04-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -255,12 +253,12 @@
                 ]
             },
             "dependsOn": [
-                "[resourceId('Microsoft.EventHub/namespaces', parameters('namespaces_SumoAzureAudit_name'))]"
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('namespaces_SumoAzureLogs_name'))]"
             ]
         },
         {
             "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
-            "name": "[concat(parameters('namespaces_SumoAzureAudit_name'), '/', parameters('eventhubs_insights_operational_logs_name'), '/', parameters('consumergroups_$Default_name'))]",
+            "name": "[concat(parameters('namespaces_SumoAzureLogs_name'), '/', parameters('eventhubs_insights_operational_logs_name'), '/', parameters('consumergroups_$Default_name'))]",
             "apiVersion": "2017-04-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -269,13 +267,13 @@
                 "updatedAt": "2018-01-17T10:01:00.7812081"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.EventHub/namespaces', parameters('namespaces_SumoAzureAudit_name'))]",
-                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaces_SumoAzureAudit_name'), parameters('eventhubs_insights_operational_logs_name'))]"
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('namespaces_SumoAzureLogs_name'))]",
+                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaces_SumoAzureLogs_name'), parameters('eventhubs_insights_operational_logs_name'))]"
             ]
         },
         {
             "type": "Microsoft.Web/sites/config",
-            "name": "[concat(parameters('sites_SumoAzureAuditApp_name'), '/', parameters('config_web_name'))]",
+            "name": "[concat(parameters('sites_SumoAzureLogsFunctionApp_name'), '/', parameters('config_web_name'))]",
             "apiVersion": "2016-08-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -302,7 +300,7 @@
                 "httpLoggingEnabled": false,
                 "logsDirectorySizeLimit": 35,
                 "detailedErrorLoggingEnabled": false,
-                "publishingUsername": "$SumoAzureAuditApp",
+                "publishingUsername": "$SumoAzureLogsApp",
                 "publishingPassword": null,
                 "appSettings": null,
                 "metadata": null,
@@ -383,22 +381,7 @@
                 "ipSecurityRestrictions": null
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('sites_SumoAzureAuditApp_name'))]"
-            ]
-        },
-        {
-            "type": "Microsoft.Web/sites/hostNameBindings",
-            "name": "[concat(parameters('sites_SumoAzureAuditApp_name'), '/', parameters('hostNameBindings_sumoazureauditapp.azurewebsites.net_name'))]",
-            "apiVersion": "2016-08-01",
-            "location": "[resourceGroup().location]",
-            "scale": null,
-            "properties": {
-                "siteName": "parameters('sites_SumoAzureAuditApp_name')",
-                "domainId": null,
-                "hostNameType": "Verified"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('sites_SumoAzureAuditApp_name'))]"
+                "[resourceId('Microsoft.Web/sites', parameters('sites_SumoAzureLogsFunctionApp_name'))]"
             ]
         }
     ]

--- a/EventHubs/src/azuredeploy_activity_logs.json
+++ b/EventHubs/src/azuredeploy_activity_logs.json
@@ -185,7 +185,7 @@
                 "type": "config",
                 "dependsOn": [
                   "[resourceId('Microsoft.Web/Sites', parameters('sites_SumoAzureLogsFunctionApp_name'))]",
-                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoAzureLogsFunctionApp_name'), 'sourcecontrolsettings')]",
+                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoAzureLogsFunctionApp_name'), 'web')]",
                   "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_SumoAzureAppLogs_name'))]"
                 ],
                 "properties": {
@@ -198,7 +198,7 @@
              },
              {
                   "apiVersion": "2015-08-01",
-                  "name": "sourcecontrolsettings",
+                  "name": "web",
                   "type": "sourcecontrols",
                   "dependsOn": [
                     "[resourceId('Microsoft.Web/sites/', parameters('sites_SumoAzureLogsFunctionApp_name'))]"

--- a/EventHubs/src/azuredeploy_metrics.json
+++ b/EventHubs/src/azuredeploy_metrics.json
@@ -2,8 +2,8 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "sites_SumoMetricsFunction_name": {
-            "defaultValue": "[concat('SumoMetricsFunction', uniqueString(resourceGroup().id))]",
+        "sites_SumoMetricsFunctionApp_name": {
+            "defaultValue": "[concat('SumoMetricsFunctionApp', uniqueString(resourceGroup().id))]",
             "type": "String"
         },
         "namespaces_SumoMetNamespace_name": {
@@ -22,7 +22,7 @@
             "defaultValue": "web",
             "type": "String"
         },
-        "storageAccounts_sumometricsfunc83e3_name": {
+        "storageAccounts_sumometricsfailedmsg": {
             "defaultValue": "[concat('sumometfail', uniqueString(resourceGroup().id))]",
             "type": "String"
         },
@@ -32,10 +32,6 @@
         },
         "AuthorizationRules_RootManageSharedAccessKey_name": {
             "defaultValue": "RootManageSharedAccessKey",
-            "type": "String"
-        },
-        "hostNameBindings_sumometricsfunction.azurewebsites.net_name": {
-            "defaultValue": "[concat('sumometricsfunction', uniqueString(resourceGroup().id),'.azurewebsites.net')]",
             "type": "String"
         },
         "consumergroups_$Default_name": {
@@ -120,7 +116,7 @@
                 "tier": "Standard"
             },
             "kind": "Storage",
-            "name": "[parameters('storageAccounts_sumometricsfunc83e3_name')]",
+            "name": "[parameters('storageAccounts_sumometricsfailedmsg')]",
             "apiVersion": "2017-10-01",
             "location": "[resourceGroup().location]",
             "tags": {},
@@ -176,30 +172,12 @@
         {
             "type": "Microsoft.Web/sites",
             "kind": "functionapp",
-            "name": "[parameters('sites_SumoMetricsFunction_name')]",
+            "name": "[parameters('sites_SumoMetricsFunctionApp_name')]",
             "apiVersion": "2016-08-01",
             "location": "[resourceGroup().location]",
             "scale": null,
             "properties": {
                 "enabled": true,
-                "hostNameSslStates": [
-                    {
-                        "name": "[concat(parameters('sites_SumoMetricsFunction_name'),'sumometricsfunction.azurewebsites.net')]",
-                        "sslState": "Disabled",
-                        "virtualIP": null,
-                        "thumbprint": null,
-                        "toUpdate": null,
-                        "hostType": "Standard"
-                    },
-                    {
-                        "name": "[concat(parameters('sites_SumoMetricsFunction_name'),'sumometricsfunction.scm.azurewebsites.net')]",
-                        "sslState": "Disabled",
-                        "virtualIP": null,
-                        "thumbprint": null,
-                        "toUpdate": null,
-                        "hostType": "Repository"
-                    }
-                ],
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverfarms_SumoMetricsAppServicePlan_name'))]",
                 "reserved": false,
                 "siteConfig": {
@@ -208,15 +186,7 @@
                         { "name": "FUNCTIONS_EXTENSION_VERSION", "value": "~1" },
                         { "name": "Project", "value": "EventHubs/target/metrics_build/" }
                     ]
-                },
-                "scmSiteAlsoStopped": false,
-                "hostingEnvironmentProfile": null,
-                "clientAffinityEnabled": false,
-                "clientCertEnabled": false,
-                "hostNamesDisabled": false,
-                "containerSize": 1536,
-                "dailyMemoryTimeQuota": 0,
-                "cloningInfo": null
+                }
             },
             "resources": [
              {
@@ -224,8 +194,8 @@
                 "name": "appsettings",
                 "type": "config",
                 "dependsOn": [
-                  "[resourceId('Microsoft.Web/Sites', parameters('sites_SumoMetricsFunction_name'))]",
-                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoMetricsFunction_name'), 'web')]",
+                  "[resourceId('Microsoft.Web/Sites', parameters('sites_SumoMetricsFunctionApp_name'))]",
+                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoMetricsFunctionApp_name'), 'sourcecontrolsettings')]",
                   "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_sumometapplogs_name'))]"
                 ],
                 "properties": {
@@ -233,15 +203,15 @@
                   "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_sumometapplogs_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_sumometapplogs_name')),'2015-05-01-preview').key1)]",
                   "SumoLabsMetricEndpoint":  "[parameters('SumoEndpointURL')]",
                   "AzureEventHubConnectionString": "[concat(listkeys(resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('namespaces_SumoMetNamespace_name'),parameters('AuthorizationRules_RootManageSharedAccessKey_name')), '2017-04-01').primaryConnectionString,';EntityPath=',parameters('eventhubs_insights_metrics_pt1m_name'))]",
-                  "StorageConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_sumometricsfunc83e3_name'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_sumometricsfunc83e3_name')),'2015-05-01-preview').key1,';EndpointSuffix=core.windows.net')]"
+                  "StorageConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccounts_sumometricsfailedmsg'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_sumometricsfailedmsg')),'2015-05-01-preview').key1,';EndpointSuffix=core.windows.net')]"
                 }
              },
              {
                   "apiVersion": "2015-08-01",
-                  "name": "web",
+                  "name": "sourcecontrolsettings",
                   "type": "sourcecontrols",
                   "dependsOn": [
-                    "[resourceId('Microsoft.Web/sites/', parameters('sites_SumoMetricsFunction_name'))]"
+                    "[resourceId('Microsoft.Web/sites/', parameters('sites_SumoMetricsFunctionApp_name'))]"
                   ],
                   "properties": {
                     "RepoUrl": "[parameters('sourceCodeRepositoryURL')]",
@@ -302,7 +272,7 @@
         },
         {
             "type": "Microsoft.Web/sites/config",
-            "name": "[concat(parameters('sites_SumoMetricsFunction_name'), '/', parameters('config_web_name'))]",
+            "name": "[concat(parameters('sites_SumoMetricsFunctionApp_name'), '/', parameters('config_web_name'))]",
             "apiVersion": "2016-08-01",
             "location": "[resourceGroup().location]",
             "scale": null,
@@ -410,22 +380,7 @@
                 "ipSecurityRestrictions": null
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('sites_SumoMetricsFunction_name'))]"
-            ]
-        },
-        {
-            "type": "Microsoft.Web/sites/hostNameBindings",
-            "name": "[concat(parameters('sites_SumoMetricsFunction_name'), '/', parameters('hostNameBindings_sumometricsfunction.azurewebsites.net_name'))]",
-            "apiVersion": "2016-08-01",
-            "location": "[resourceGroup().location]",
-            "scale": null,
-            "properties": {
-                "siteName": "parameters('sites_SumoMetricsFunction_name')",
-                "domainId": null,
-                "hostNameType": "Verified"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('sites_SumoMetricsFunction_name'))]"
+                "[resourceId('Microsoft.Web/sites', parameters('sites_SumoMetricsFunctionApp_name'))]"
             ]
         }
     ]

--- a/EventHubs/src/azuredeploy_metrics.json
+++ b/EventHubs/src/azuredeploy_metrics.json
@@ -195,7 +195,7 @@
                 "type": "config",
                 "dependsOn": [
                   "[resourceId('Microsoft.Web/Sites', parameters('sites_SumoMetricsFunctionApp_name'))]",
-                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoMetricsFunctionApp_name'), 'sourcecontrolsettings')]",
+                  "[resourceId('Microsoft.Web/Sites/sourcecontrols', parameters('sites_SumoMetricsFunctionApp_name'), 'web')]",
                   "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_sumometapplogs_name'))]"
                 ],
                 "properties": {
@@ -208,7 +208,7 @@
              },
              {
                   "apiVersion": "2015-08-01",
-                  "name": "sourcecontrolsettings",
+                  "name": "web",
                   "type": "sourcecontrols",
                   "dependsOn": [
                     "[resourceId('Microsoft.Web/sites/', parameters('sites_SumoMetricsFunctionApp_name'))]"

--- a/EventHubs/src/index.js
+++ b/EventHubs/src/index.js
@@ -9,11 +9,11 @@ var sumoClient;
 
 module.exports = function (context, eventHubMessages) {
     //var options ={ 'urlString':process.env.APPSETTING_SumoSelfEventHubBadEndpoint,'metadata':{}, 'MaxAttempts':3, 'RetryInterval':3000,'compress_data':true};
-    var options ={ 'urlString':process.env.APPSETTING_SumoAuditEndpoint,'metadata':{}, 'MaxAttempts':3, 'RetryInterval':3000,'compress_data':true};
-    
-    
-   
-    
+    var options ={ 'urlString':process.env.APPSETTING_SumoLogsEndpoint,'metadata':{}, 'MaxAttempts':3, 'RetryInterval':3000,'compress_data':true};
+
+
+
+
     sumoClient = new sumoHttp.SumoClient(options,context,failureHandler,successHandler);
     var transformer = new dataTransformer.Transformer();
     var messageArray = transformer.azureAudit(eventHubMessages);

--- a/EventHubs/target/logs_build/EventHubs_Logs/index.js
+++ b/EventHubs/target/logs_build/EventHubs_Logs/index.js
@@ -9,11 +9,11 @@ var sumoClient;
 
 module.exports = function (context, eventHubMessages) {
     //var options ={ 'urlString':process.env.APPSETTING_SumoSelfEventHubBadEndpoint,'metadata':{}, 'MaxAttempts':3, 'RetryInterval':3000,'compress_data':true};
-    var options ={ 'urlString':process.env.APPSETTING_SumoAuditEndpoint,'metadata':{}, 'MaxAttempts':3, 'RetryInterval':3000,'compress_data':true};
-    
-    
-   
-    
+    var options ={ 'urlString':process.env.APPSETTING_SumoLogsEndpoint,'metadata':{}, 'MaxAttempts':3, 'RetryInterval':3000,'compress_data':true};
+
+
+
+
     sumoClient = new sumoHttp.SumoClient(options,context,failureHandler,successHandler);
     var transformer = new dataTransformer.Transformer();
     var messageArray = transformer.azureAudit(eventHubMessages);

--- a/EventHubs/tests/test_eventhub_logs.py
+++ b/EventHubs/tests/test_eventhub_logs.py
@@ -6,7 +6,6 @@ import sys
 sys.path.insert(0, '../../test_utils')
 from basetest import BaseTest
 from azure.mgmt.resource import ResourceManagementClient
-from azure.mgmt.resource.resources.models import DeploymentMode
 from azure.mgmt.eventhub import EventHubManagementClient
 from azure.mgmt.storage import StorageManagementClient
 from azure.cosmosdb.table.tableservice import TableService
@@ -23,17 +22,18 @@ class TestEventHubLogs(BaseTest):
         self.RESOURCE_GROUP_NAME = "TestEventHubLogs-%s" % (
             datetime.datetime.now().strftime("%d-%m-%y-%H-%M-%S"))
 
-        self.STORAGE_ACCOUNT_NAME = "sumoazureauditapplogs"
+        self.STORAGE_ACCOUNT_NAME = "sumoapplogs"
 
         self.function_name_prefix = "EventHubs_Logs"
 
         self.resource_client = ResourceManagementClient(self.credentials,
                                                         self.subscription_id)
         self.template_name = 'azuredeploy_activity_logs.json'
+        self.event_hub_namespace_prefix = "SumoAzureLogsNamespaces"
         try:
             self.sumo_endpoint_url = os.environ["SumoEndpointURL"]
         except KeyError:
-            raise Exception("SumoEndpointURL/StorageAcccountConnectionString environment variables are not set")
+            raise Exception("SumoEndpointURL environment variables are not set")
 
         self.repo_name, self.branch_name = self.get_git_info()
 
@@ -58,7 +58,7 @@ class TestEventHubLogs(BaseTest):
 
     def insert_mock_logs_in_EventHub(self):
         print("Inserting fake logs in EventHub")
-        namespace_name = self.get_resource_name("SumoAzureAudit", "Microsoft.EventHub/namespaces")
+        namespace_name = self.get_resource_name(self.event_hub_namespace_prefix, "Microsoft.EventHub/namespaces")
         eventhub_name = 'insights-operational-logs'
         defaultauthorule_name = "RootManageSharedAccessKey"
 
@@ -84,7 +84,7 @@ class TestEventHubLogs(BaseTest):
         sleep(60)
         storage_client = StorageManagementClient(self.credentials,
                                                  self.subscription_id)
-        STORAGE_ACCOUNT_NAME = self.get_resource_name("sumoaudlogs", "Microsoft.Storage/storageAccounts")
+        STORAGE_ACCOUNT_NAME = self.get_resource_name(self.STORAGE_ACCOUNT_NAME, "Microsoft.Storage/storageAccounts")
         storage_keys = storage_client.storage_accounts.list_keys(
             self.RESOURCE_GROUP_NAME, STORAGE_ACCOUNT_NAME)
         acckey = storage_keys.keys[0].value

--- a/EventHubs/tests/test_eventhub_metrics.py
+++ b/EventHubs/tests/test_eventhub_metrics.py
@@ -6,7 +6,6 @@ import sys
 sys.path.insert(0, '../../test_utils')
 from basetest import BaseTest
 from azure.mgmt.resource import ResourceManagementClient
-from azure.mgmt.resource.resources.models import DeploymentMode
 from azure.mgmt.eventhub import EventHubManagementClient
 from azure.mgmt.storage import StorageManagementClient
 from azure.cosmosdb.table.tableservice import TableService
@@ -29,7 +28,7 @@ class TestEventHubMetrics(BaseTest):
         try:
             self.sumo_endpoint_url = os.environ["SumoEndpointURL"]
         except KeyError:
-            raise Exception("SumoEndpointURL/StorageAcccountConnectionString environment variables are not set")
+            raise Exception("SumoEndpointURL environment variables are not set")
 
         self.repo_name, self.branch_name = self.get_git_info()
 


### PR DESCRIPTION
1) removed hostname bindings (they are created by default so not needed)
2) changes in tests to accommodate name changes
3) changed the resources names in event hub logs and metrics template.
