### PR TITLE
Handle null file extensions as log files

### DIFF
--- a/BlockBlobReader/src/consumer.js
+++ b/BlockBlobReader/src/consumer.js
@@ -247,6 +247,9 @@ function getBlockBlobService(context, task) {
 
 function messageHandler(serviceBusTask, context, sumoClient) {
     var file_ext = serviceBusTask.blobName.split(".").pop();
+    if (file_ext == serviceBusTask.blobName) {
+        file_ext = "log";
+    }
     var msghandler = {"log": logHandler, "csv": csvHandler, "json": jsonHandler, "blob": blobHandler};
     if (!(file_ext in msghandler)) {
         context.done("Unknown file extension: " + file_ext + " for blob: " + serviceBusTask.blobName);


### PR DESCRIPTION
Many logs that are auto-generated by Azure resources (e.g. from turning on App Service logging with no other configuration, or when enabling logging for WebJobs from an App Service) do not use a file extension. This causes the consumer function to fail when attempting to upload these logs. 

This change compares the file_ext variable in the messageHandler function to the blobName. If they're the same, which would only be the case if there were no file extension on the blobName, it tells the consumer to handle the the messages as log files, where users can then parse the files within the SumoLogic software as they need.