### PR TITLE
make sure context.done is invoked

### DIFF
--- a/EventHubs/target/logs_build/EventHubs_Logs/index.js
+++ b/EventHubs/target/logs_build/EventHubs_Logs/index.js
@@ -29,18 +29,17 @@ module.exports = function (context, eventHubMessages) {
         ctx.log("Failed to send to Sumo, backup to storageaccount now");
         if (sumoClient.messagesAttempted === sumoClient.messagesReceived) {
             context.bindings.outputBlob = messageArray.map(function(x) { return JSON.stringify(x);}).join("\n");
-            context.done();
         }
+        context.done();
     }
     function successHandler(ctx) {
         ctx.log('Successfully sent to Sumo');
         if (sumoClient.messagesAttempted === sumoClient.messagesReceived) {
             ctx.log('Sent all data to Sumo. Exit now.');
-            context.done();
         }
+        context.done();
     }
     context.log("Flushing the rest of the buffers:");
     sumoClient.flushAll();
-
 };
 

--- a/EventHubs/target/metrics_build/EventHubs_Metrics/index.js
+++ b/EventHubs/target/metrics_build/EventHubs_Metrics/index.js
@@ -62,15 +62,15 @@ module.exports = function (context, eventHubMessages) {
         ctx.log("Failed to send metrics to Sumo");
         if (sumoMetricClient.messagesAttempted === sumoMetricClient.messagesReceived) {
             context.bindings.outputBlob = messageArray.map(function(x) { return JSON.stringify(x);}).join("\n");
-            context.done();
         }
+        context.done();
     }
     function successHandler(ctx) {
         ctx.log('Successfully sent to Sumo');
         if (sumoMetricClient.messagesAttempted === sumoMetricClient.messagesReceived) {
             ctx.log('Sent all metric data to Sumo. Exit now.');
-            context.done();
         }
+        context.done();
     }
 
     context.log("Flushing the rest of the buffers:");


### PR DESCRIPTION
Version 1 Javascript Function Apps must invoke `context.done()`. As the code is currently written, `context.done()` will not be invoked in the event the `if` block within the handlers does not execute. In my experience, this has been 100% of the time (though the events are always being submitted successfully).

When `context.done()` is not invoked, there is a 20% chance that the function will run up to the time limit even though the logic has completed successfully. This PR guarantees that `context.done()` will be invoked before the function exits (only for the event hub code, I did not take the time to verify if this bug exists in the Blog Storage integration code).

Edit: fixed some typos