### PR TITLE
Updated removing package json path issue

### DIFF
--- a/BlockBlobReader/src/create_zip.sh
+++ b/BlockBlobReader/src/create_zip.sh
@@ -64,7 +64,7 @@ cd ../../
 
 echo "removing packagejson"
 
-rm producer_build/BlobTaskProducerpackage.json
+rm producer_build/BlobTaskProducer/package.json
 rm consumer_build/BlobTaskConsumer/package.json
 rm dlqprocessor_build/DLQTaskConsumer/package.json
 


### PR DESCRIPTION
Updated line in create script.

original: `rm producer_build/BlobTaskProducerpackage.json`

update: `rm producer_build/BlobTaskProducer/package.json`

This matches the consumer and dlqprocessor builds.