### PR TITLE
Build and package BlockBlobReader functions when tagging releases to support zip deployment

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -9,11 +9,82 @@ on:
       - "v*"
 
 jobs:
+  build-blockblobreader:
+    name: Build BlockBlobReader 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          node-version: 18
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Create packages
+        run: |
+          cd BlockBlobReader/target
+
+          echo "Installing npm modules for BlobTaskConsumer..."
+          cd consumer_build
+          npm install
+          cd ..
+
+          echo "Installing npm modules for DLQConsumer..."
+          cd dlqprocessor_build
+          npm install
+          cd ..
+
+          echo "Installing npm modules for BlobTaskConsumer..."
+          cd producer_build
+          npm install
+          cd ..
+
+          cd ../src
+          echo "Running npm build..."
+          npm run build
+
+          echo "Preparing target_zip directory..."
+          rm -rf ../target_zip
+          cp -r ../target ../target_zip
+
+          cd ../target_zip
+
+          rm -f .DS_Store
+
+          echo "Creating consumer_build zip package..."
+          cd consumer_build;
+          zip -r ../BlockBlobReaderConsumer.zip ./* ;
+          cd ..;
+
+          echo "Creating dlqprocessor_build zip package..."
+          cd dlqprocessor_build;
+          zip -r ../BlockBlobReaderDLQProcessor.zip ./* ;
+          cd ..;
+
+          echo "Creating producer_build zip package..."
+          cd producer_build;
+          zip -r ../BlockBlobReaderProducer.zip ./* ;
+          cd ..;
+
+      - name: Upload BlockBlobReader artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: blockblobreader_${{ github.ref_name }}
+          if-no-files-found: error
+          path: ./BlockBlobReader/target_zip/*.zip
+
   tagged-release:
     name: "Tagged Release"
     runs-on: ubuntu-latest
+    needs: build-blockblobreader
     steps:
+      - name: Download BlockBlobReader artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: blockblobreader_${{ github.ref_name }}
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
+          files: ./*.zip
+          


### PR DESCRIPTION
We are unable to use [App Service's source control sync](https://github.com/SumoLogic/sumologic-azure-function/blob/master/BlockBlobReader/src/blobreaderdeploy.json#L398-L411) for the build and deployment of the BlockBlobReader Azure Functions and instead are using zip-based deployments. We cannot use the source code artifacts produced when a GitHub release is created as these are missing the `node_modules` required at runtime.

It appears that `.zip` packages were previously created ([blobreaderzipdeploy.json](https://github.com/SumoLogic/sumologic-azure-function/blob/master/BlockBlobReader/src/blobreaderzipdeploy.json#L342)) but I am unable to find any packages other than the initial `1.0.0` versions.

This PR updates the `npm-publish-github-packages.yml` GitHub Actions workflow to automatically build and individually package the BlockBlobReader Azure Functions into `.zip` files that can be used when deploying via ZIP deploy. The additional step is based on the existing [create_zip.sh](https://github.com/SumoLogic/sumologic-azure-function/blob/master/BlockBlobReader/src/create_zip.sh) script, however, instead of uploading the packages to an external service, they are added as additional GitHub release artifacts.

e.g.
![image](https://github.com/SumoLogic/sumologic-azure-function/assets/1689544/2f142a07-6897-431d-8ab8-8362f86e730d)
